### PR TITLE
Revert "travis: use `faucet` to shorten TAP output"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ node_js:
 before_install:
   - npm install -g npm
   - npm --version
-script: "npm run test-faucet"
 sudo: false
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "tape test/index.js",
-    "test-faucet": "faucet"
+    "test": "tape test/index.js"
   },
   "dependencies": {
     "capitalize": "^1.0.0",
@@ -29,7 +28,6 @@
     "url-join": "^0.0.1"
   },
   "devDependencies": {
-    "faucet": "^0.0.1",
     "is-plain-object": "^2.0.1",
     "is-string": "^1.0.4",
     "isstream": "^0.1.2",


### PR DESCRIPTION
This reverts commit b6d19f45212bd03a13a4303881937eafc86bd1a0 since it did not actually fix https://github.com/KenanY/overrustle-logs/issues/1.
